### PR TITLE
Change the viewport-fit so `env(safe-area-inset-bottom, 0)` is evaluated by Safari properly.

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -12,9 +12,16 @@
 namespace ACPL\MobileTab;
 
 use Flarum\Extend;
+use Flarum\Frontend\Document;
 
 return [
     (new Extend\Frontend('forum'))->js(__DIR__.'/js/dist/forum.js')->css(__DIR__.'/less/forum.less'),
 
     new Extend\Locales(__DIR__.'/locale'),
+
+    (new Extend\Frontend('forum'))
+        ->content(function (Document $document) {
+            $document->meta['viewport'] = "{$document->meta['viewport']}, viewport-fit=cover";
+        }),
+
 ];

--- a/less/forum.less
+++ b/less/forum.less
@@ -15,7 +15,7 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  height: var(--mobile-tab-height);
+  height: ~"calc(var(--mobile-tab-height) + env(safe-area-inset-bottom, 0))";
   background: var(--mobile-tab-bg);
   box-shadow: var(--mobile-tab-shadow);
   z-index: var(--mobile-tab-zindex);


### PR DESCRIPTION
This fix is specific to the bottom safe area for IOS (and maybe if some android devices have these).

I deployed 2 different sites so they can be tested individually, only two extensions installed: Flarum PWA & Mobile Tab.

https://before-pwa-fix.pigeons.dev/

https://after-pwa-fix.pigeons.dev/


Before:

![CleanShot 2024-04-05 at 17 01 16@2x](https://github.com/android-com-pl/mobile-tab/assets/1993075/b8dc714b-d27d-45f7-9248-c2b1fb5bb5ca)

After:

![CleanShot 2024-04-05 at 17 01 22@2x](https://github.com/android-com-pl/mobile-tab/assets/1993075/1b061337-75e8-4282-a79c-f32b5751badd)

---

It seems like `safe-area-inset-bottom` isn't evaluated when `viewport-fit` is not set to `cover`.

As a side effect, this is the change that happens when viewing the device on landscape.

Before:
![Before Landscape](https://github.com/android-com-pl/mobile-tab/assets/1993075/2e5aa84a-8f25-4890-8481-4ef5ad51d02d)

After:
![After Landscape](https://github.com/android-com-pl/mobile-tab/assets/1993075/aed31c3d-180c-4fc4-9347-4856d6fd5b2f)

---

Tested also with an android device which didn't have any changes on my end.

![Android Landscape](https://github.com/android-com-pl/mobile-tab/assets/1993075/9ac51004-f86d-4d0c-98b1-4320e44d508d)

![Android Portrait](https://github.com/android-com-pl/mobile-tab/assets/1993075/5bb9bb1b-69d7-4040-a11d-94a93686e6a1)



